### PR TITLE
Update Composition API docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A curated list of awesome things related to Vue 3
 ## Official
 
 - [Official Documentation](https://v3.vuejs.org/)
-- [Vue Composition API](https://composition-api.vuejs.org/)
+- [Vue Composition API](https://v3.vuejs.org/guide/introduction.html)
 - [RFCs for substantial changes / feature additions to Vue core](https://github.com/vuejs/rfcs)
 
 ## Related awesome lists


### PR DESCRIPTION
The https://composition-api.vuejs.org/ docs are out-of-date to the current implementation. Should refer to vue3 docs instead.

https://v3.vuejs.org/guide/introduction.html