### PR TITLE
add vue 3 social sharing plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ A curated list of awesome things related to Vue 3
 - [V-privacy](https://github.com/fchancel/v-privacy) - A Vue 3 plugin that allows you to manage the privacy of an HTML element by blurring its content and optional encrypt node text data in DOM.
 - [Vuersatile Components](https://www.andres-brugarolas.com/vuersatile-components/) - A Vue 3 component library, with form self-validation and a SCSS framework integrated.
 - [Vue 3 Easter Egg Trigger](https://github.com/webdevnerdstuff/vue3-easter-egg-trigger) - This packages makes it nice and easy to add Easter Egg triggers to your Vue3 site.
+- [Vue 3 social sharing](https://github.com/hedint/vue3-social-sharing) - Style agnostic Vue 3 plugin for sharing your links on major social networks.
+
 
 ## Examples
 


### PR DESCRIPTION
vue3-social-sharing is a style agnostic Vue 3 plugin for sharing your links on major social networks.
Besides the plugin, can be used as a renderless component and composable. Also typescript friendly!