### PR TITLE
Add TutorialSearch to Courses

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ A curated list of awesome things related to Vue 3
 ## Courses
 
 - [The Vue.js 3 Master Class](https://vueschool.io/courses/the-vuejs-3-master-class)
+- [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 - [What's new in Vue 3](https://vueschool.io/courses/whats-new-in-vue-3)
 - [Vue 3 Essentials](https://www.vuemastery.com/courses/vue-3-essentials/why-the-composition-api/)
 - [Vue 3 Deep Dive with Evan You](https://www.vuemastery.com/courses/vue3-deep-dive-with-evan-you/vue3-overview/)

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ A curated list of awesome things related to Vue 3
 ## Courses
 
 - [The Vue.js 3 Master Class](https://vueschool.io/courses/the-vuejs-3-master-class)
-- [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
+- [TutorialSearch](https://tutorialsearch.io/browse/web-development/laravel-vue) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 - [What's new in Vue 3](https://vueschool.io/courses/whats-new-in-vue-3)
 - [Vue 3 Essentials](https://www.vuemastery.com/courses/vue-3-essentials/why-the-composition-api/)
 - [Vue 3 Deep Dive with Evan You](https://www.vuemastery.com/courses/vue3-deep-dive-with-evan-you/vue3-overview/)


### PR DESCRIPTION
Hi! This PR adds **TutorialSearch** to the *Courses* section.

### What is TutorialSearch?
[TutorialSearch](https://tutorialsearch.io/browse/web-development/laravel-vue) is a free, cross-platform search engine that indexes 50,000+ tutorials and courses from major learning platforms (Udemy, Skillshare, Pluralsight, and more) across 45+ categories — including programming, web development, AI/ML, cybersecurity, design, and more. No signup required.

It helps learners compare tutorials side-by-side by rating, price, and reviews before committing to a course, which I think makes it a useful addition to this list.

### Entry added
```
- [TutorialSearch](https://tutorialsearch.io/browse/web-development/laravel-vue) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
```

Inserted in alphabetical order within the section. Happy to adjust formatting, description length, or placement if you'd like — just let me know!

Thanks for maintaining this list.